### PR TITLE
Fix for Python 3.11 (offset-[aware/naive] datetimes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This little bot can ban recently joined users to prevent/cleanup bot spam waves.
 
 I'm hosting a public instance of this bot. You can invite it using [this link](https://discord.com/oauth2/authorize?client_id=907638667600883795&scope=bot&permissions=4). If you have questions or want to report bugs, use the [issues](https://github.com/muckelba/ValoBattlepassCalcBot/issues) tab.
 
-**Make sure to grant the bot ban rights!**
+**MAKE SURE TO GRANT THE BOT BAN RIGHTS AND ENABLE ALL PRIVILEGED GATEWAY INTENTS!**
 
 ## Installation
 
@@ -17,7 +17,7 @@ Install the requirements:
 pip install -r requirements.txt
 ```
 
-Copy and rename `config.ini.example` to `config.ini` and paste the discord bottoken and configure the list of roles that are allowed to use the bot. The `bantext` option can be used to send users a DM before banning them to give false positives a chance to contact you. Set it to `""` to disable this feature. 
+Copy and rename `config.ini.example` to `config.ini` and paste the discord bottoken and configure the list of roles that are allowed to use the bot. 
 
 Run the bot:
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ I'm hosting a public instance of this bot. You can invite it using [this link](h
 
 ## Installation
 
-Python 3.6+ required, only tested 3.8!
+Python 3.6+ required, only tested 3.8 and 3.11!
 
 Install the requirements:
 ```bash

--- a/bot.py
+++ b/bot.py
@@ -9,9 +9,14 @@ import configparser
 import random 
 from string import ascii_uppercase
 import os
+from datetime import datetime, date
 
-intents = discord.Intents.default()
-intents.members = True
+from dateutil.relativedelta import relativedelta, FR, TU
+from dateutil.easter import easter
+from dateutil.parser import parse
+from dateutil import rrule
+
+intents = discord.Intents.all()
 client = commands.Bot(command_prefix = "!", intents=intents)
 
 config = configparser.ConfigParser()
@@ -45,8 +50,8 @@ async def botspam(ctx, joined="60", created=None):
     recentlyJoined = []
 
     for member in ctx.guild.members:
-        if member.joined_at > datetime.utcnow() - timedelta(minutes=joined) and member != client.user:
-            if (not created) or (created and member.created_at > datetime.utcnow() - timedelta(days=created)):
+        if member.joined_at > datetime.now(timezone.utc) - timedelta(minutes=joined) and member != client.user:
+            if (not created) or (created and member.created_at > datetime.now(timezone.utc) - timedelta(days=created)):
                 recentlyJoined.append(member)
 
     if not recentlyJoined:
@@ -59,8 +64,8 @@ async def botspam(ctx, joined="60", created=None):
     with open(filename, "w") as text_file:
         accounts = []
         for account in recentlyJoined:
-            accountjoined = datetime.utcnow() - account.joined_at
-            accountcreated = datetime.utcnow() - account.created_at
+            accountjoined = datetime.now(timezone.utc) - account.joined_at
+            accountcreated = datetime.now(timezone.utc) - account.created_at
             accounts.append(f"{account.name}#{account.discriminator}, joined {int(accountjoined.seconds / 60)} minutes ago, created {int(accountcreated.days)} days ago.") 
 
         text_file.write('\n'.join(str(line) for line in accounts))

--- a/bot.py
+++ b/bot.py
@@ -93,7 +93,7 @@ async def botspam(ctx, joined="60", created=None):
                 await ctx.send(f"User could not be banned, error:\n ```{str(e)}```")
                 continue
             logging.info(f"{member} banned")
-            await asyncio.sleep(3)
+            await asyncio.sleep(5)
 
         await ctx.send("Members banned successfully!")
 

--- a/bot.py
+++ b/bot.py
@@ -24,7 +24,6 @@ config.read('config.ini')
 
 token = config['main']['token']
 admins = json.loads(config['main']['admins'])
-bantext = config['main']['bantext']
 
 logging.basicConfig(
     format='[%(asctime)s] %(message)s',
@@ -89,9 +88,6 @@ async def botspam(ctx, joined="60", created=None):
         await ctx.send(f"Banning {len(recentlyJoined)} users...")
         for member in recentlyJoined:
             try:
-                if bantext:
-                    dmchannel = await member.create_dm()
-                    await dmchannel.send(bantext)
                 await member.ban(reason="Bot spam. Automatically banned by massban bot")
             except Exception as e:
                 await ctx.send(f"User could not be banned, error:\n ```{str(e)}```")

--- a/bot.py
+++ b/bot.py
@@ -93,7 +93,7 @@ async def botspam(ctx, joined="60", created=None):
                 await ctx.send(f"User could not be banned, error:\n ```{str(e)}```")
                 continue
             logging.info(f"{member} banned")
-            await asyncio.sleep(5)
+            await asyncio.sleep(3)
 
         await ctx.send("Members banned successfully!")
 


### PR DESCRIPTION
Fixes `TypeError: can't subtract offset-naive and offset-aware datetimes` and removes ban DM to prevent the bot from being quarantined (basically locked down forever).